### PR TITLE
Addition of IncidentProton

### DIFF
--- a/openmc/data/__init__.py
+++ b/openmc/data/__init__.py
@@ -12,6 +12,7 @@ WMP_VERSION = (WMP_VERSION_MAJOR, WMP_VERSION_MINOR)
 from .data import *
 from .neutron import *
 from .photon import *
+from .proton import *
 from .decay import *
 from .reaction import *
 from . import ace

--- a/openmc/data/proton.py
+++ b/openmc/data/proton.py
@@ -371,7 +371,8 @@ class IncidentProton(EqualityMixin):
         for mf, mt, nc, mod in ev.reaction_list:
             if mf == 3:
                 data.reactions[mt] = ProtonReaction.from_endf(ev, mt)
-        
+
+        data._evaluation = ev        
         return data
     
     @classmethod
@@ -465,6 +466,12 @@ class IncidentProton(EqualityMixin):
             that are less backwards compatible but have performance benefits.
 
         """
+
+        # If data come from ENDF, don't allow exporting to HDF5
+        if hasattr(self, '_evaluation'):
+            raise NotImplementedError('Cannot export incident neutron data that '
+                                      'originated from an ENDF file.')
+
         # Open file and write version
         f = h5py.File(str(path), mode, libver=libver)
         f.attrs['filetype'] = np.string_('data_proton')

--- a/openmc/data/proton.py
+++ b/openmc/data/proton.py
@@ -1,0 +1,274 @@
+from collections import OrderedDict
+from collections.abc import Mapping, Callable
+from io import StringIO
+from numbers import Integral, Real
+
+import h5py
+import numpy as np
+
+from openmc.mixin import EqualityMixin
+import openmc.checkvalue as cv
+from . import HDF5_VERSION
+from .ace import Table, get_metadata, get_table
+from .data import ATOMIC_SYMBOL
+from .endf import Evaluation, get_head_record, get_tab1_record, get_list_record
+from .function import Tabulated1D
+
+_REACTION_NAME = {2: '(p,elastic)', 4: '(p,level)', 5: '(p,misc)', 11: '(p,2nd)', 
+                  16: '(p,2n)', 17: '(p,3n)', 18: '(p,fission)', 22: '(p,na)', 
+                  24: '(p,2na)', 25: '(p,3na)', 28: '(p,np)', 29: '(p,n2a)',
+                  30: '(p,2n2a)', 32: '(p,nd)', 33: '(p,nt)', 34: '(p,nHe-3)',
+                  35: '(p,nd2a)', 36: '(p,nt2a)', 37: '(p,4n)', 41: '(p,2np)', 
+                  42: '(p,3np)', 44: '(p,n2p)', 45: '(p,npa)', 91: '(p,nc)', 
+                  102: '(p,gamma)', 103: '(p,p)', 104: '(p,d)', 105: '(p,t)', 
+                  106: '(p,3He)', 107: '(p,a)', 108: '(p,2a)', 109: '(p,3a)', 
+                  111: '(p,2p)', 112: '(p,pa)', 113: '(p,t2a)', 114: '(p,d2a)', 
+                  115: '(p,pd)', 116: '(p,pt)', 117: '(p,da)',  203: '(p,Xp)',
+                 204: '(p,Xd)', 205: '(p,Xt)', 206: '(p,X3He)', 207: '(p,Xa)',
+                 301: 'heating', 444: 'damage-energy', 699: '(p,dc)', 749: '(p,tc)', 
+                 799: '(p,3Hec)', 849: '(p,ac)', 891: '(p,2nc)', 
+                 901: 'heating-local'}
+_REACTION_NAME.update({i: '(p,n{})'.format(i - 50) for i in range(50, 91)})
+_REACTION_NAME.update({i: '(p,d{})'.format(i - 650) for i in range(650, 699)})
+_REACTION_NAME.update({i: '(p,t{})'.format(i - 700) for i in range(700, 749)})
+_REACTION_NAME.update({i: '(p,3He{})'.format(i - 750) for i in range(750, 799)})
+_REACTION_NAME.update({i: '(p,a{})'.format(i - 800) for i in range(800, 849)})
+_REACTION_NAME.update({i: '(p,2n{})'.format(i - 875) for i in range(875, 891)})
+
+class ProtonReaction(EqualityMixin):
+
+    def __init__(self, mt):
+        self.mt = mt
+        self._xs = None
+
+    def __repr__(self):
+        if self.mt in _REACTION_NAME:
+            return "<Photon Reaction: MT={} {}>".format(
+                self.mt, _REACTION_NAME[self.mt][0])
+        else:
+            return "<Photon Reaction: MT={}>".format(self.mt)
+
+    @property
+    def xs(self):
+        return self._xs
+
+    @xs.setter
+    def xs(self, xs):
+        cv.check_type('reaction cross section', xs, Callable)
+        self._xs = xs
+
+    @classmethod
+    def from_endf(cls, ev, mt):
+        """Generate proton reaction from an ENDF evaluation
+
+        Parameters
+        ----------
+        ev : openmc.data.endf.Evaluation
+            ENDF photo-atomic interaction data evaluation
+        mt : int
+            The MT value of the reaction to get data for
+
+        Returns
+        -------
+        openmc.data.PhotonReaction
+            Photon reaction data
+
+        """
+
+        rx = cls(mt)
+
+        # Integrated cross sections
+        if (3, mt) in ev.section:
+            file_obj = StringIO(ev.section[3, mt])
+            get_head_record(file_obj)
+            rx.xs = get_tab1_record(file_obj)[1]
+
+        
+        return rx
+
+    #  A little redundant
+    def to_hdf5(self, group, energy):
+        """Write photon reaction to an HDF5 group
+
+        Parameters
+        ----------
+        group : h5py.Group
+            HDF5 group to write to
+
+        """
+
+
+        group.attrs['mt'] = self.mt
+        if self.mt in _REACTION_NAME:
+            group.attrs['label'] = np.string_(_REACTION_NAME[self.mt])
+        else:
+            group.attrs['label'] = np.string_(self.mt)
+
+        group.create_dataset('xs', data=self.xs(energy))
+        
+
+
+
+class IncidentProton(EqualityMixin):
+    """Photon interaction data.
+
+    This class stores data derived from an ENDF-6 format proton interaction
+    sublibrary. Instances of this class are not normally instantiated by the
+    user but rather created using the factory methods
+    :meth:`IncidentProton.from_hdf5`, :meth:`IncidentProton.from_ace`, and
+    :meth:`IncidentProton.from_endf`.
+
+    Parameters
+    ----------
+    atomic_number : int
+        Number of protons in the target nucleus
+
+    Attributes
+    ----------
+    atomic_number : int
+        Number of protons in the target nucleus
+    reactions : collections.OrderedDict
+        Contains the cross sections for each photon reaction. The keys are MT
+        values and the values are instances of :class:`ProtonReaction`.
+
+    """
+
+    def __init__(self, name, atomic_number, mass_number):
+        self.name = name
+        self.atomic_number = atomic_number
+        self.mass_number = mass_number
+        self.reactions = OrderedDict()
+
+    def __contains__(self, mt):
+        return mt in self.reactions
+
+    def __getitem__(self, mt):
+        if mt in self.reactions:
+            return self.reactions[mt]
+        else:
+            raise KeyError('No reaction with MT={}.'.format(mt))
+
+    def __repr__(self):
+        return "<IncidentProton: {}>".format(self.name)
+
+    def __iter__(self):
+        return iter(self.reactions.values())
+
+    @property
+    def atomic_number(self):
+        return self._atomic_number
+
+    @property
+    def name(self):
+        return self._name
+    
+    @property
+    def mass_number(self):
+        return self._mass_number
+
+
+    @name.setter
+    def name(self, name):
+        cv.check_type('name', name, str)
+        self._name = name
+
+    @atomic_number.setter
+    def atomic_number(self, atomic_number):
+        cv.check_type('atomic number', atomic_number, Integral)
+        cv.check_greater_than('atomic number', atomic_number, 0, True)
+        self._atomic_number = atomic_number
+
+    @mass_number.setter
+    def mass_number(self, mass_number):
+        cv.check_type('mass number', mass_number, Integral)
+        cv.check_greater_than('mass number', mass_number, 0, True)
+        self._mass_number = mass_number
+
+
+    @classmethod
+    def from_endf(cls, ev_or_filename):
+        """Generate incident proton data from an ENDF evaluation
+
+        Parameters
+        ----------
+        ev_or_filename : openmc.data.endf.Evaluation or str
+            ENDF evaluation to read from. If given as a string, it is assumed to
+            be the filename for the ENDF file.
+  
+
+        Returns
+        -------
+        openmc.data.IncidentProton
+            Proton interaction data
+
+      """
+
+        if isinstance(ev_or_filename, Evaluation):
+            ev = ev_or_filename
+        else:
+            ev = Evaluation(ev_or_filename)
+
+
+        atomic_number = ev.target['atomic_number']
+        mass_number = ev.target['mass_number']
+
+        element = ATOMIC_SYMBOL[atomic_number]
+        name = '{}{}'.format(element, mass_number)
+
+        data = cls(name, atomic_number, mass_number)
+
+        # Read each reaction
+        for mf, mt, nc, mod in ev.reaction_list:
+            if mf == 3:
+                data.reactions[mt] = ProtonReaction.from_endf(ev, mt)
+
+        return data
+
+    
+
+    def export_to_hdf5(self, path, mode='a', libver='earliest'):
+        """Export incident photon data to an HDF5 file.
+
+        Parameters
+        ----------
+        path : str
+            Path to write HDF5 file to
+        mode : {'r', 'r+', 'w', 'x', 'a'}
+            Mode that is used to open the HDF5 file. This is the second argument
+            to the :class:`h5py.File` constructor.
+        libver : {'earliest', 'latest'}
+            Compatibility mode for the HDF5 file. 'latest' will produce files
+            that are less backwards compatible but have performance benefits.
+
+        """
+        # Open file and write version
+        f = h5py.File(str(path), mode, libver=libver)
+        f.attrs['filetype'] = np.string_('data_proton')
+        if 'version' not in f.attrs:
+            f.attrs['version'] = np.array(HDF5_VERSION)
+
+        group = f.create_group(self.name)
+        group.attrs['Z'] = self.atomic_number
+        group.attrs['A'] = self.mass_number
+
+        # Determine union energy grid
+        union_grid = np.array([])
+        for rx in self:
+            union_grid = np.union1d(union_grid, rx.xs.x)
+        group.create_dataset('energy', data=union_grid)
+
+        # Write cross sections
+        for mt, rx in self.reactions.items():
+            key = _REACTION_NAME[mt][1]
+            # Only elastic cross section for now
+            if mt == 2:
+                sub_group = group.create_group(key)
+            else:
+                continue
+
+            rx.to_hdf5(sub_group, union_grid)
+        
+        f.close()
+
+
+

--- a/openmc/data/proton.py
+++ b/openmc/data/proton.py
@@ -46,10 +46,10 @@ class ProtonReaction(EqualityMixin):
 
     def __repr__(self):
         if self.mt in _REACTION_NAME:
-            return "<Photon Reaction: MT={} {}>".format(
-                self.mt, _REACTION_NAME[self.mt][0])
+            return "<Proton Reaction: MT={} {}>".format(
+                self.mt, _REACTION_NAME[self.mt])
         else:
-            return "<Photon Reaction: MT={}>".format(self.mt)
+            return "<Proton Reaction: MT={}>".format(self.mt)
 
     @property
     def xs(self):
@@ -223,7 +223,7 @@ class IncidentProton(EqualityMixin):
     atomic_number : int
         Number of protons in the target nucleus
     reactions : collections.OrderedDict
-        Contains the cross sections for each photon reaction. The keys are MT
+        Contains the cross sections for each proton reaction. The keys are MT
         values and the values are instances of :class:`ProtonReaction`.
 
     """
@@ -317,13 +317,6 @@ class IncidentProton(EqualityMixin):
         for mf, mt, nc, mod in ev.reaction_list:
             if mf == 3:
                 data.reactions[mt] = ProtonReaction.from_endf(ev, mt)
-
-        # Determine union energy grid
-        union_grid = np.array([])
-        for rx in data:
-            union_grid = np.union1d(union_grid, rx.xs.x)
-
-        data.energy = union_grid
         
         return data
     
@@ -404,7 +397,7 @@ class IncidentProton(EqualityMixin):
         return data
 
     def export_to_hdf5(self, path, mode='a', libver='earliest'):
-        """Export incident photon data to an HDF5 file.
+        """Export incident proton data to an HDF5 file.
 
         Parameters
         ----------

--- a/openmc/plotter.py
+++ b/openmc/plotter.py
@@ -62,7 +62,7 @@ PLOT_TYPES_LINEAR = {'nu-fission / fission', 'nu-scatter / scatter',
 _MIN_E = 1.e-5
 _MAX_E = 20.e6
 _MIN_E_PROTON = 1.e2
-_MAX_E_PROTON = 20.e8
+_MAX_E_PROTON = 2.e9
 
 
 

--- a/openmc/plotter.py
+++ b/openmc/plotter.py
@@ -496,7 +496,10 @@ def _calculate_cexs_nuclide(this, types, particle_type, temperature=294.,
                                 # reactions like MT=4
                                 funcs.append(nuc[mt].xs[nucT])
                     else:
-                        funcs.append(nuc[mt].xs[nucT])
+                        if particle_type == 'neutron':
+                            funcs.append(nuc[mt].xs[nucT])
+                        elif particle_type == 'proton':
+                            funcs.append(nuc[mt].xs)
                 elif mt == UNITY_MT:
                     funcs.append(lambda x: 1.)
                 elif mt == XI_MT:


### PR DESCRIPTION
This PR is for issue 9 on our task list. @davidjohnlong has also contributed to this work. The task is essentially complete, although I am confirming a few things with Tim. As discussed I have opened the pull request now as most of it can be reviewed. 

This PR adds a new `IncidentProton` class which is based on the `IncidentNeutron` class. 
This class allows the user to create an HDF5 file using Proton data from ACE or ENDF libraries. Conversion from ENDF requires the use of the `from_njoy` method which runs the ENDF file through NJOY to re-tabulate cross sections.

Some changes have also been made to `openmc.plotter.py` to allow it to plot proton cross sections. A `particle_type`  argument which can be set to proton for proton handling. The default is still neutron.

I have done most of the testing of these developments using the TENDL-2019 library. The ace version of TENDL-2019 includes example plots of included data. I have inspected a range of hdf5 files to confirm that they have the correct format. I have also plotted cross sections from libraries generated from both ACE and ENDF files and compared them with the TENDL references where appropriate. The IncidentProton class and plotter additions seem to be working as expected. I am still discussing some issues I have seen with with Tim, but these are likely to be issues with certain nuclides. 

I haven't added any unit tests as there is no proton data in the code release by default. I don't think this functionality will be in mainstream use so unit tests might not be required. 

One potential outstanding issue is that `plotter` isn't handling some cross section plotting correctly. This would have been an issue before these developments so I'm not sure if we need to make the fixes. Basically, `plotter` has sum rules on certain types of cross section plotting which allow it sum certain ENDF MT reactions:
https://github.com/SamPUG/openmc/blob/d9d9155c7339df02fc921ebc5741d792a36614ee/openmc/plotter.py#L32-L42

So if the total cross section is requested then MT=2 (elastic) and MT=3 (inelastic) cross-sections are summed if they exist. However, the current implementation ignores the fact that MT=3 may not be explicitly defined - inelastic scattering can also be calculated using a sum rule. For example, B10 has two reactions in its ace file, MT=2 and MT=5. Even though there is no MT=3 reaction, we still have an inelastic cross section as MT=5 is part of the MT=3 sum rule. In the first plot below we can see that the total cross section is equal to MT=2 which is incorrect. The total cross section should include the contribution from MT=5 and the total cross section should look like it does in the second plot, which was downloaded from the TENDL site.
![B10](https://user-images.githubusercontent.com/18268481/76987809-b5110580-693b-11ea-8050-5070df15fe00.png)
![B010chk_principal2](https://user-images.githubusercontent.com/18268481/76987430-0d93d300-693b-11ea-9552-7c38813d558c.png)
There are also similar issues with the 'absorption', 'capture' and 'fission' plot types as these also have sum rules which aren't being used. I assume this behavior could be altered, but I'm not sure it is in the scope of our developments. What do you think?






